### PR TITLE
fix: docker build command on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ The generated Dockerfile will be located at `./8.0/Dockefile`.
 To build this image locally and try it out, you can run the following:
 
 ```bash
-cd 8.0
-docker build -t test/mysql:8.0 .
+docker build -t test/mysql:8.0 -f 8.0/Dockerfile .
 docker run -it test/mysql:8.0 bash
 ```
 


### PR DESCRIPTION
The docker build command in the Generating Dockerfiles section of README.md is incorrect, so I fixed it.

When I run docker build according to README, I get an error.

```shell
$ ./shared/gen-dockerfiles.sh 8.0.29

$ cd 8.0

$ docker build -t test/mysql:8.0 .
[+] Building 0.1s (7/8)
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 2.15kB                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/cimg/base:2022.01                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                       0.0s
 => [1/4] FROM docker.io/cimg/base:2022.01                                                                                                                                                            0.0s
 => CACHED [2/4] RUN groupadd -r mysql && useradd -r -g mysql mysql &&  mkdir /docker-entrypoint-initdb.d &&  UBUNTU_VERSION=$(lsb_release -r -s) &&  if [ 8 == "5" ]; then   UBUNTU_VERSION=18.04;   0.0s
 => ERROR [3/4] COPY docker-entrypoint.sh /usr/local/bin/                                                                                                                                             0.0s
------
 > [3/4] COPY docker-entrypoint.sh /usr/local/bin/:
------
failed to compute cache key: "/docker-entrypoint.sh" not found: not found
```

So, I fixed this command.
I tested and confirmed to work correctly.

```
$ docker build -t test/mysql:8.0 -f 8.0/Dockerfile .
[+] Building 0.2s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 2.15kB                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/cimg/base:2022.01                                                                                                                                          0.0s
 => [1/4] FROM docker.io/cimg/base:2022.01                                                                                                                                                            0.0s
 => [internal] load build context                                                                                                                                                                     0.0s
 => => transferring context: 14.59kB                                                                                                                                                                  0.0s
 => CACHED [2/4] RUN groupadd -r mysql && useradd -r -g mysql mysql &&  mkdir /docker-entrypoint-initdb.d &&  UBUNTU_VERSION=$(lsb_release -r -s) &&  if [ 8 == "5" ]; then   UBUNTU_VERSION=18.04;   0.0s
 => CACHED [3/4] COPY docker-entrypoint.sh /usr/local/bin/                                                                                                                                            0.0s
 => CACHED [4/4] RUN ln -s usr/local/bin/docker-entrypoint.sh / &&  chmod +x /usr/local/bin/docker-entrypoint.sh &&  chown -R mysql:mysql /usr/local/bin/docker-entrypoint.sh &&  mysql --version |   0.0s
 => exporting to image                                                                                                                                                                                0.0s
 => => exporting layers                                                                                                                                                                               0.0s
 => => writing image sha256:4dfe9c7437d7cf254c26a471148e5cc96fb14f120a83f95acdbf11452d9999ea                                                                                                          0.0s
 => => naming to docker.io/test/mysql:8.0    
```