### PR TITLE
chore: add @CPEng and @images as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Automatically request PR reviews from the CPE Team as a whole and the Images sub-team specifically
+# Automatically request PR reviews from the CPE Team as a whole and the Images subteam
 *	@CircleCI-Public/cpeng @CircleCI-Public/images


### PR DESCRIPTION
Update Codeowners to encompass teams rather than individuals | standardizes the comment