### PR TITLE
Publish v8.0.33. [release]

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/base:2023.04
+FROM cimg/base:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/%%PARENT%%:2023.04
+FROM cimg/%%PARENT%%:2023.07
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 


### PR DESCRIPTION
The last 2 PRs were merged with a merge commit instead of squashed so the new releases were never deployed. This PR needs to be reviewed and double checked that it will be squashed with the title `Publish v8.0.33. [release]` to prevent this issue from arising again
