### PR TITLE
8.0.32 support continuation

### DIFF
--- a/8.0.32/Dockerfile
+++ b/8.0.32/Dockerfile
@@ -6,7 +6,7 @@ FROM cimg/base:current
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV MYSQL_VERSION=8.0.33 \
+ENV MYSQL_VERSION=8.0.32 \
 	MYSQL_VERSION_MAJOR=8 \
 	MYSQL_VERSION_MINOR=8.0
 

--- a/8.0.32/Dockerfile
+++ b/8.0.32/Dockerfile
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/base:current
+FROM cimg/base:2025.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/base:current
+FROM cimg/base:2025.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 8.0/Dockerfile -t cimg/mysql:8.0.33  -t cimg/mysql:8.0 .
+docker build --file 8.0/Dockerfile -t cimg/mysql:8.0.33 -t cimg/mysql:8.0 .
+
+docker build --file 8.0.32/Dockerfile -t cimg/mysql:8.0.32 .

--- a/push-images.sh
+++ b/push-images.sh
@@ -2,4 +2,5 @@
 # Do not edit by hand; please use build scripts/templates to make changes
 
 docker push cimg/mysql:8.0.33
+docker push cimg/mysql:8.0.32
 docker push cimg/mysql:8.0


### PR DESCRIPTION
I have not made changes to the template but I'm asking for `8.0.32` to be an available supported version. `8.0.33` is not acceptable because the current default `8.0` version for AWS Aurora MySQL databases is `8.0.32`.

Can we at least keep that version available for that reason alone? `8.0.33` is not the latest version anyways.

Your base `cimg` is out of date enough to be worthy of concern. There's no reason not to keep it as current to get the patches.
