### PR TITLE
Update cimg-base to 2026.03-22.04

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM cimg/%%PARENT%%:2025.05
+FROM cimg/%%PARENT%%:2026.03-22.04
 
 LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 


### PR DESCRIPTION
Updates the base image tag from `2025.05` to `2026.03-22.04`.